### PR TITLE
`meArm::end()` function added

### DIFF
--- a/meArm.cpp
+++ b/meArm.cpp
@@ -66,6 +66,13 @@ void meArm::begin(int pinBase, int pinShoulder, int pinElbow, int pinGripper) {
   openGripper();
 }
 
+void meArm::end() {
+  _base.detach();
+  _shoulder.detach();
+  _elbow.detach();
+  _gripper.detach();
+}
+
 //Set servos to reach a certain point directly without caring how we get there 
 void meArm::goDirectlyTo(float x, float y, float z) {
   float radBase,radShoulder,radElbow;

--- a/meArm.h
+++ b/meArm.h
@@ -32,6 +32,7 @@ class meArm {
       int sweepMinGripper=75, int sweepMaxGripper=115, float angleMinGripper=pi/2, float angleMaxGripper=0);
     //required before running
     void begin(int pinBase, int pinShoulder, int pinElbow, int pinGripper);
+    void end();
     //Travel smoothly from current point to another point
     void gotoPoint(float x, float y, float z);
     //Set servos to reach a certain point directly without caring how we get there 


### PR DESCRIPTION
It detaches attached servos inside the object. For example, needed when you want to disarm `meArm` object and use `Servo` objects instead.